### PR TITLE
Added includes that seemed to be required on Ubuntu and g++ 9.4.0

### DIFF
--- a/src/Display.h
+++ b/src/Display.h
@@ -4,6 +4,8 @@
 #include <vector>
 #include <string>
 #include <sstream>
+#include <algorithm>
+#include <cstring>
 
 #include "Matrices.h"
 


### PR DESCRIPTION
I was unable to compile out of the box on my system until I added algorithm and cstring to the includes.  I think that shouldn't be an issue in terms of minimal dependencies?